### PR TITLE
Fix session startup notice

### DIFF
--- a/db/config.php
+++ b/db/config.php
@@ -2,8 +2,10 @@
 // Inicia o buffer de saída
 ob_start();
 
-// Inicia a sessão
-session_start();
+// Inicia a sessão apenas se ainda não estiver iniciada
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 require "conexao.php";
 
 // Verificar se as variáveis de sessão estão definidas e não estão vazias


### PR DESCRIPTION
## Summary
- guard `session_start()` in `db/config.php`

## Testing
- `php -l db/config.php`
- `php -l int.php`
- `php test4.php` *(no session notice, expected failure due to missing connection)*

------
https://chatgpt.com/codex/tasks/task_e_688d094927248332b27973123b8c5be1